### PR TITLE
subject: feat(database): Fix desktop OS support (like Windows) by using sqlite_common_ffi

### DIFF
--- a/lib/repository/conversation.dart
+++ b/lib/repository/conversation.dart
@@ -1,6 +1,8 @@
 import 'package:dart_openai/dart_openai.dart';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:platform/platform.dart';
 
 class Conversation {
   String name;
@@ -82,6 +84,12 @@ class ConversationRepository {
 
   Future<Database> _getDb() async {
     if (_database == null) {
+      const Platform platform = LocalPlatform();
+      if (platform.isWindows || platform.isLinux || platform.isMacOS) {
+        // Initialize FFI
+        sqfliteFfiInit();
+        databaseFactory = databaseFactoryFfi;
+      }
       final String path = join(await getDatabasesPath(), 'chatgpt.db');
       _database = await openDatabase(path, version: 1,
           onCreate: (Database db, int version) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -645,6 +645,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.5"
+  sqflite_common_ffi:
+    dependency: "direct main"
+    description:
+      name: sqflite_common_ffi
+      sha256: f86de82d37403af491b21920a696b19f01465b596f545d1acd4d29a0a72418ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.5"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: f7511ddd6a2dda8ded9d849f8a925bb6020e0faa59db2443debc18d484e59401
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -829,6 +845,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   flex_color_scheme: ^7.0.5
   get_storage: ^2.1.1
   dart_openai: ^1.9.92
+  sqflite_common_ffi: ^2.2.5
 
 dev_dependencies:
   flutter_test:

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -31,6 +31,11 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
+  // Flutter can complete the first frame before the "show window" callback is
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
+  flutter_controller_->ForceRedraw();
+
   return true;
 }
 


### PR DESCRIPTION
body:
- Add sqflite_common_ffi package to pubspec.yaml for desktop OS support
- Initialize and use sqflite_ffi database factory in conversation.dart for Windows, Linux, and macOS
- Call ForceRedraw() on flutter_controller_ to ensure a frame is pending and window is shown on Windows
- Fixes desktop OS support for the app